### PR TITLE
Fix strictdi to support minification

### DIFF
--- a/src/ui-codemirror.js
+++ b/src/ui-codemirror.js
@@ -5,7 +5,7 @@
  */
 angular.module('ui.codemirror', [])
   .constant('uiCodemirrorConfig', {})
-  .directive('uiCodemirror', uiCodemirrorDirective);
+  .directive('uiCodemirror', ['$timeout', '$rootScope', 'uiCodemirrorConfig', uiCodemirrorDirective]);
 
 /**
  * @ngInject


### PR DESCRIPTION
This plugin cannot be minified as it is not compatible with angular's [`strictDi`](https://docs.angularjs.org/error/$injector/strictdi) flag.
This PT fixes the problem.